### PR TITLE
Add location path for tracking UTM parameters correctly

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -21,7 +21,7 @@ export default function ({ app: { router }}, inject) {
 
   if (!<%= options.disableAutoPageTrack %>) {
     router.afterEach((to) => {
-      gtag('config', '<%= options.id %>', { 'page_path': to.fullPath })
+      gtag('config', '<%= options.id %>', { 'page_path': to.fullPath, 'location_path': window.location.origin + to.fullPath })
     })
   }
 


### PR DESCRIPTION
Added `page_location` property with `page_path` for tracking UTM parameters without reload.
Used `window.location.origin` for getting origin but it's optional, if you feel window can create problem in some time you can remove origin name, only `to.fullPath` will be enough for doing the job.

